### PR TITLE
Add initial-scale=1 to viewport metatag

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">


### PR DESCRIPTION
Missing 'initial-scale=1' can have unintended effects, so it's best to have this in the viewport metatag. 