### PR TITLE
fix: use correct meta_image url accessor

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -13,7 +13,7 @@
 		<meta name="og:title" content={$page.data.meta_title} />
 	{/if}
 	{#if $page.data.meta_image}
-		<meta name="og:image" content={$page.data.meta_image.url} />
+		<meta name="og:image" content={$page.data.meta_image} />
 		<meta name="twitter:card" content="summary_large_image" />
 	{/if}
 </svelte:head>


### PR DESCRIPTION
The OG image currently doesn't work because we are destructuring the object in `+page.server.js`: 
```js
export async function load({ fetch, cookies }) {
	const client = createClient({ fetch, cookies });
	const page = await client.getByUID('page', 'home');

	return {
                //...
		meta_image: page.data.meta_image.url
	};
}
```

And then reference `meta_image.url` again in the +layout.svelte file when it's now a string, not an object: 
```js
<meta name="og:image" content={$page.data.meta_image.url} />
```

Removing the second `.url` makes the OG image successfully render